### PR TITLE
Fix header safe area overlap on mobile

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,9 +7,12 @@ body {
 }
 
 @layer utilities {
-	.text-balance {
-		text-wrap: balance;
-	}
+        .text-balance {
+                text-wrap: balance;
+        }
+        .safe-area-top {
+                padding-top: var(--safe-area-inset-top);
+        }
 	/* Improved scrollbar utilities */
 	.scrollbar-hide {
 		scrollbar-width: none;
@@ -184,9 +187,10 @@ body {
 }
 
 @layer base {
-	:root {
-		/* Zugzology Mushroom Theme - Light Mode */
-		--primary: 206 55 37;
+        :root {
+                --safe-area-inset-top: env(safe-area-inset-top, 0px);
+                /* Zugzology Mushroom Theme - Light Mode */
+                --primary: 206 55 37;
 		/* Psilocybin Blue - professional, trustworthy */
 		--primary-foreground: 0 0 100;
 
@@ -240,14 +244,15 @@ body {
 		--sidebar-accent-foreground: 8 10 16;
 		--sidebar-border: 48 20 85;
 		--sidebar-ring: 206 55 37;
-		--header-top-height: 60px;
-		--header-nav-height: 40px;
-		--header-height: calc(var(--header-top-height) + var(--header-nav-height));
-		--header-offset: var(--header-height);
-		--removed-body-scroll-bar-size: 0px;
-	}
-	.dark {
-		--primary: 206 55 37;
+                --header-top-height: 60px;
+                --header-nav-height: 40px;
+                --header-height: calc(var(--safe-area-inset-top) + var(--header-top-height) + var(--header-nav-height));
+                --header-offset: var(--header-height);
+                --removed-body-scroll-bar-size: 0px;
+        }
+        .dark {
+                --safe-area-inset-top: env(safe-area-inset-top, 0px);
+                --primary: 206 55 37;
 		/* Psilocybin Blue - same brand color in both modes */
 		--primary-foreground: 0 0 100;
 

--- a/src/components/layout/header/header-client.tsx
+++ b/src/components/layout/header/header-client.tsx
@@ -385,9 +385,9 @@ export function HeaderClient({ initialMenuItems, blogs, isAuthenticated }: Heade
 		return null;
 	}
 
-	return (
-		<>
-			<header className="sticky top-0 z-50 flex flex-col bg-background">
+        return (
+                <>
+                        <header className="safe-area-top sticky top-0 z-50 flex flex-col bg-background">
 				{/* Dynamic Promo Banner - Hidden */}
 				{/* <DynamicPromoBanner onDismiss={() => setShowPromo(false)} showPromo={showPromo} /> */}
 

--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -91,11 +91,11 @@ async function HeaderContent() {
 
 // Loading component with skeleton UI
 function HeaderLoading() {
-	return (
-		<div className="h-16 w-full animate-pulse bg-background">
-			<div className="mx-auto flex h-full max-w-screen-xl items-center justify-between px-4">
-				<div className="h-8 w-32 rounded bg-muted" />
-				<div className="mx-4 flex-1">
+        return (
+                <div className="safe-area-top h-16 w-full animate-pulse bg-background">
+                        <div className="mx-auto flex h-full max-w-screen-xl items-center justify-between px-4">
+                                <div className="h-8 w-32 rounded bg-muted" />
+                                <div className="mx-4 flex-1">
 					<div className="h-10 w-full rounded bg-muted" />
 				</div>
 				<div className="flex space-x-2">


### PR DESCRIPTION
## Summary
- add a reusable safe-area padding utility and expose the browser safe-area inset as a CSS variable
- include the safe-area offset in global header height calculations so downstream layouts stay aligned
- apply the safe-area padding to the live header and its loading skeleton to prevent mobile browser chrome overlap

## Testing
- npm run lint *(fails: existing Biome violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f0d2e46ecc8326be294971d3b90c2d