### PR TITLE
Fix Vercel production build (login + sitemap)

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -8,6 +8,8 @@ import { getSiteSettings } from "@/lib/actions/shopify";
 import { getEnhancedBreadcrumbSchema, getSearchActionSchema } from "@/lib/seo/enhanced-jsonld";
 import { generateMetadata as generateSEOMetadata } from "@/lib/seo/seo-utils";
 
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = generateSEOMetadata({
 	title: "Sign In - Customer Login",
 	description:

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -112,28 +112,42 @@ async function getAllShopifyData() {
 		}
 	`;
 
-	const { data } = await shopifyFetch<any>({
-		query,
-		cache: "force-cache",
-		next: {
-			tags: ["sitemap"],
-			revalidate: 3600, // Revalidate every hour
-		},
-	});
+	try {
+		const { data } = await shopifyFetch<any>({
+			query,
+			cache: "force-cache",
+			next: {
+				tags: ["sitemap"],
+				revalidate: 3600, // Revalidate every hour
+			},
+		});
 
-	return {
-		shop: data.shop,
-		products: data.products.edges.map((edge: any) => edge.node),
-		collections: data.collections.edges.map((edge: any) => edge.node),
-		blogs: data.blogs.edges.map((edge: any) => edge.node),
-		articles: data.blogs.edges.flatMap((edge: any) =>
-			edge.node.articles.edges.map((articleEdge: any) => ({
-				...articleEdge.node,
-				blog: { handle: edge.node.handle, title: edge.node.title },
-			}))
-		),
-		menuItems: data.menu?.items || [],
-	};
+		const blogEdges = data?.blogs?.edges ?? [];
+
+		return {
+			shop: data?.shop ?? null,
+			products: (data?.products?.edges ?? []).map((edge: any) => edge.node),
+			collections: (data?.collections?.edges ?? []).map((edge: any) => edge.node),
+			blogs: blogEdges.map((edge: any) => edge.node),
+			articles: blogEdges.flatMap((edge: any) =>
+				(edge.node?.articles?.edges ?? []).map((articleEdge: any) => ({
+					...articleEdge.node,
+					blog: { handle: edge.node.handle, title: edge.node.title },
+				}))
+			),
+			menuItems: data?.menu?.items || [],
+		};
+	} catch {
+		// Shopify outage / missing credentials: keep sitemap buildable with static routes only
+		return {
+			shop: null,
+			products: [],
+			collections: [],
+			blogs: [],
+			articles: [],
+			menuItems: [],
+		};
+	}
 }
 
 // Helper function to generate alternate language URLs if needed

--- a/src/lib/actions/session.ts
+++ b/src/lib/actions/session.ts
@@ -47,8 +47,13 @@ export async function getSession(): Promise<Session> {
 			},
 			expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(), // 24 hours from now
 		};
-	} catch (_error) {
-		throw new SessionError("Failed to get session");
+	} catch {
+		// During static prerender / build, cookies() can be unavailable.
+		// Treat as logged out so pages like /login can still build.
+		return {
+			user: null,
+			expires: null,
+		};
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixes the Vercel production deploy failure after the Shopify outage PR merge.
- `getSession()` now returns a logged-out session when `cookies()` is unavailable during prerender/build.
- Marks `/login` as `force-dynamic`.
- Hardens sitemap Shopify parsing so missing Storefront data no longer throws during SSG.

## Verification
- `npm run build` succeeds locally after these changes.

## Test plan
- [ ] Merge to `main` and confirm Vercel production deploy succeeds
- [ ] `/login` loads normally in production
- [ ] `/sitemap/main.xml` returns without 500 when Shopify is unavailable
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbb412ba-5a36-4877-b29c-1b8ff2af58f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbb412ba-5a36-4877-b29c-1b8ff2af58f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

